### PR TITLE
Add Gigapipe to Adopters

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,7 @@ Perses is a [Cloud Native Computing Foundation](https://cncf.io) sandbox project
 - [![Pydantic logo](assets/images/logos/Pydantic_dark_theme.png#only-dark)](https://pydantic.dev/) [![Pydantic logo](assets/images/logos/Pydantic_light_theme.png#only-light)](https://pydantic.dev/)
 - [![RedHat logo](assets/images/logos/RedHat_dark_theme.png#only-dark)](https://www.redhat.com) [![RedHat logo](assets/images/logos/RedHat_light_theme.png#only-light)](https://www.redhat.com)
 - [![SAP logo](assets/images/logos/SAP.svg)](https://www.sap.com)
+- [![GIGAPIPE logo](assets/images/logos/gigapipe.svg)](https://www.gigapipe.com)
 - [Your company logo here](./adopters.md)
 
 </div>

--- a/site/assets/images/logos/gigapipe.svg
+++ b/site/assets/images/logos/gigapipe.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1000">
+  <g data-name="Layer 2">
+    <path d="M500 333.34 666.66 500 500 666.66 333.34 500ZM875 625l125-125L500 0 0 500l500 500 333.34-333.33-125-125L500 750 250 500l250-250 250 250Z" style="fill:#7d12ff" data-name="Layer 1"/>
+  </g>
+</svg>


### PR DESCRIPTION
Submitting Gigapipe for the Adopters page. 

Gigapipe is dutch company developing a 100% opensource AGPLv3 polyglot observability stack drop-in compatible with Prometheus, Tempo, Loki and Pyroscope and natively compatible with Perses. We're heavy adopters present and future - our plan is to develop and contribute log and pprof plugins and datasources. 

If any changes are needed, we'd be happy to provide info or changes.  