### PR TITLE
display only the intro of each blog post

### DIFF
--- a/docs/blog/posts/community-dashboards.md
+++ b/docs/blog/posts/community-dashboards.md
@@ -20,6 +20,8 @@ The Mixins Dashboards helped bring about a sense of relief, as users now could u
 
 The end result is, that despite the promise of reusable dashboards, the reality is there’s still not a widely used solution for automatic dashboards creation.
 
+<!-- more -->
+
 ## Perses KubeCon EU Recap - Maybe there’s a better way to build Dashboards 
 
 During **KubeCon EU 2025** in London, two of Perses’ core maintainers, Nicolas Takashi and Antoine Thébaud, shared how Perses is changing the way engineers develop and manage dashboards as code. Their talk covered the power of the Open Dashboard Model, how to use strongly typed code with the Perses Go SDK, and why this approach fits naturally into CI/CD pipelines using modern GitOps practices. If you didn’t get a chance to watch it live, you can watch the full session [here](http://youtube.com/watch?v=7h70Olo5Uzk).

--- a/docs/blog/posts/v0.50.0.md
+++ b/docs/blog/posts/v0.50.0.md
@@ -13,6 +13,8 @@ improvements in this release.
 
 See the complete release note for more details: [v0.50.0](https://github.com/perses/perses/releases/tag/v0.50.0)
 
+<!-- more -->
+
 ## Migration
 
 One of the greatest contents of this release is the migration that has been drastically improved.

--- a/docs/blog/posts/v0.51.0.md
+++ b/docs/blog/posts/v0.51.0.md
@@ -20,6 +20,8 @@ containing all default plugins supported by Perses.
 We have also made significant improvements to the documentation, highlighting features that were implemented some time
 ago but not well advertised, such as datasource discovery and ephemeral dashboards.
 
+<!-- more -->
+
 ## New Plugins system
 
 Big news from us at Perses! We've rolled out a brand-new plugin system, and it's all about making things more flexible


### PR DESCRIPTION
Instead of displaying the entire content of each blog post, we are now displaying only the introduction of each posts.

That makes the index page easier to browse.