### PR TITLE
Update Concepts list + Provision a globaldatasource for the Perses-hosted Prometheus

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,14 +103,15 @@ nav:
   - Docs:
       - Overview: perses/docs/overview.md
       - Concepts:
-          - Plugins: perses/docs/concepts/plugins.md
+          - Plugin: perses/docs/concepts/plugin.md
           - Dashboard-as-Code: perses/docs/concepts/dashboard-as-code.md
+          - Datasource: perses/docs/concepts/datasource.md
+          - Variable: perses/docs/concepts/variable.md
           - Datasource & Variable scopes: perses/docs/concepts/datasource-and-variable-scopes.md
-          - Datasources: perses/docs/concepts/datasources.md
           - Authentication: perses/docs/concepts/authentication.md
           - Authorization: perses/docs/concepts/authorization.md
           - Proxy: perses/docs/concepts/proxy.md
-          - Ephemeral Dashboards: perses/docs/concepts/ephemeral-dashboards.md
+          - Ephemeral Dashboard: perses/docs/concepts/ephemeral-dashboard.md
       - User Docs:
           - Installation:
               - Installing Perses from Source: perses/docs/installation/from-source.md

--- a/provisioning/globaldatasources/PrometheusLocal.json
+++ b/provisioning/globaldatasources/PrometheusLocal.json
@@ -1,21 +1,18 @@
 {
   "kind": "GlobalDatasource",
   "metadata": {
-    "name": "PrometheusLocal",
-    "createdAt": "0001-01-01T00:00:00Z",
-    "updatedAt": "2023-09-21T16:22:57.1323033Z",
-    "version": 2
+    "name": "PrometheusLocal"
   },
   "spec": {
     "display": {
-      "description": "Local prometheus instance for testing"
+      "name": "Prometheus Local",
+      "description": "Your locally-hosted Prometheus instance for testing"
     },
     "default": false,
     "plugin": {
       "kind": "PrometheusDatasource",
       "spec": {
         "directUrl": "http://localhost:9090",
-        "scrapeInterval": ""
       }
     }
   }

--- a/provisioning/globaldatasources/PrometheusPerses.json
+++ b/provisioning/globaldatasources/PrometheusPerses.json
@@ -1,12 +1,12 @@
 {
   "kind": "GlobalDatasource",
   "metadata": {
-    "name": "PrometheusDemo"
+    "name": "PrometheusPerses"
   },
   "spec": {
     "display": {
-      "name": "Prometheus Demo instance",
-      "description": "The official Prometheus demo instance maintained by Prometheus org"
+      "name": "Prometheus Perses",
+      "description": "A Prometheus demo instance hosted by Perses org"
     },
     "default": true,
     "plugin": {
@@ -15,7 +15,7 @@
         "proxy": {
           "kind": "HTTPProxy",
           "spec": {
-            "url": "https://prometheus.demo.prometheus.io"
+            "url": "http://prometheus:9090"
           }
         }
       }


### PR DESCRIPTION
- Doc: reference the new Variable doc + reorder + fix broken links (= adjust to https://github.com/perses/perses/pull/3138/files)
- Provision a new globaldatasource for the Perses-hosted Prometheus (= the one from the [docker-compose](https://github.com/perses/website/blob/main/docker-compose.yaml#L32-L37))