### PR TITLE
Make adopter doc link clearer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -201,6 +201,6 @@ Perses is a [Cloud Native Computing Foundation](https://cncf.io) sandbox project
 - [![Pydantic logo](assets/images/logos/Pydantic_dark_theme.png#only-dark)](https://pydantic.dev/) [![Pydantic logo](assets/images/logos/Pydantic_light_theme.png#only-light)](https://pydantic.dev/)
 - [![RedHat logo](assets/images/logos/RedHat_dark_theme.png#only-dark)](https://www.redhat.com) [![RedHat logo](assets/images/logos/RedHat_light_theme.png#only-light)](https://www.redhat.com)
 - [![SAP logo](assets/images/logos/SAP.svg)](https://www.sap.com)
-- [Your company logo here](./adopters.md)
+- <div style="display: flex; align-items: center; justify-content: center; height: 100%;"><a href="./adopters.md">Want your company logo here?</a></div>
 
 </div>


### PR DESCRIPTION
A colleague raised that our current design for the last Adopters tile (contains adopters doc link) made it misleading, it was too much looking like alt text for a missing image. Thus I added some styling & rephrased it as a question to avoid any confusion.

Before:
<img width="651" height="265" alt="image" src="https://github.com/user-attachments/assets/6ceb56b3-f704-45c0-b702-ee372381c9fb" />

After:
<img width="625" height="246" alt="image" src="https://github.com/user-attachments/assets/d9974d15-1a48-43bc-9fbb-1baefe026365" />
